### PR TITLE
Fix unused GraphQL config init block

### DIFF
--- a/plugins/ApolloGraphQL/src/commonMain/kotlin/io/github/jan/supabase/graphql/GraphQL.kt
+++ b/plugins/ApolloGraphQL/src/commonMain/kotlin/io/github/jan/supabase/graphql/GraphQL.kt
@@ -50,7 +50,7 @@ sealed interface GraphQL: MainPlugin<GraphQL.Config> {
         }
 
         override fun createConfig(init: Config.() -> Unit): Config {
-            return Config()
+            return Config().apply(init)
         }
 
     }


### PR DESCRIPTION
Hopefully everything works fine. Not at my machine, this was done via Github code editor.